### PR TITLE
Log request ID for credit redemption

### DIFF
--- a/codex-cli/src/utils/get-api-key.tsx
+++ b/codex-cli/src/utils/get-api-key.tsx
@@ -2,6 +2,7 @@ import type { Choice } from "./get-api-key-components";
 import type { Request, Response } from "express";
 
 import { ApiKeyPrompt, WaitingForAuth } from "./get-api-key-components";
+import { log } from "./logger/log.js";
 import chalk from "chalk";
 import express from "express";
 import fs from "fs/promises";
@@ -221,11 +222,22 @@ async function maybeRedeemCredits(
         ? "https://api.openai.com"
         : "https://api.openai.org";
 
-    const redeemRes = await fetch(`${apiHost}/v1/billing/redeem_credits`, {
+    const redeemUrl = `${apiHost}/v1/billing/redeem_credits`;
+    const redeemRes = await fetch(redeemUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id_token: currentIdToken }),
     });
+
+    // Log request ID for troubleshooting
+    const requestId =
+      redeemRes.headers.get("x-request-id") ||
+      redeemRes.headers.get("openai-request-id");
+    if (requestId) {
+      log(`Redeem credits request to ${redeemUrl} (id: ${requestId})`);
+    } else {
+      log(`Redeem credits request to ${redeemUrl} (no request id returned)`);
+    }
 
     if (!redeemRes.ok) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- log request id from OpenAI response when running `codex --free`

## Testing
- `pnpm install`
- `pnpm test` *(fails: Process with PID failed to terminate)*
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6868ede0c7f883249c089c0dda6d05fe